### PR TITLE
Add trove classifier to convey Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Framework :: Django',
         'License :: OSI Approved :: BSD License',
     ],


### PR DESCRIPTION
This adds the right [trove classifier](https://pypi.python.org/pypi?%3Aaction=list_classifiers) so tools automatically checking for Python 3 support detect this package as compatible.

Examples of such tools would be Django Packages (Wagtail grid: https://djangopackages.org/grids/g/wagtail-cms/) or the "Can I use Python 3?" cli (https://github.com/brettcannon/caniusepython3).

Note that those tools only look at the versions published on pypi, so a new version will need to be published for those to pick up the change.