### PR TITLE
Add new setting to configure plugin visibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ Install using pip::
 
 Then add 'wagtailaccessibility' to your INSTALLED_APPS. It works with Wagtail 1.0 and upwards.
 
+If you want to restrict visibility of the template tag to specific groups, add a 'WAGTAIL_ACCESSIBILITY_GROUPS' setting with a list of groups. For example::
+
+    WAGTAIL_ACCESSIBILITY_GROUPS = ["editors", "moderators"]
+
 Using
 =====
 

--- a/wagtailaccessibility/templatetags/wagtailaccessibility_tags.py
+++ b/wagtailaccessibility/templatetags/wagtailaccessibility_tags.py
@@ -1,13 +1,27 @@
 from django import template
 from django.template.loader import render_to_string
+from django.db.models.functions import Lower
+from django.conf import settings
 
 register = template.Library()
 
 
+def has_visibility(user):
+    visibility_groups = getattr(settings, "WAGTAIL_ACCESSIBILITY_GROUPS", [])
+    if not visibility_groups:
+        #  Show overlay for all users if groups have not been
+        #  configured in settings
+        return True
+    groups = list(user.groups.values_list(Lower("name"), flat=True))
+    if set(groups) & set(visibility_groups):
+        return True
+    return False
+
+
 @register.simple_tag(takes_context=True)
 def tota11y(context, override=False):
-    request = context['request']
-    if override or getattr(request, 'is_preview', False):
-        return render_to_string('wagtailaccessibility/tota11y.html')
-    else:
-        return ""
+    request = context["request"]
+    if has_visibility(request.user):
+        if override or getattr(request, "is_preview", False):
+            return render_to_string("wagtailaccessibility/tota11y.html")
+    return ""


### PR DESCRIPTION
This adds support for a new, optional setting ('WAGTAIL_ACCESSIBILITY_GROUPS') which allows site developers to restrict visibility of the template tag to specific groups.