### PR TITLE
Support Django 3

### DIFF
--- a/wagtailaccessibility/templates/wagtailaccessibility/tota11y.html
+++ b/wagtailaccessibility/templates/wagtailaccessibility/tota11y.html
@@ -1,2 +1,2 @@
-{% load staticfiles %}
+{% load static %}
 <script src="{% static 'js/tota11y.min.js' %}"></script>


### PR DESCRIPTION
`loadstatic` was deprecated in 2.1, and no longer works in 3.x:

https://docs.djangoproject.com/en/3.0/releases/2.1/#features-deprecated-in-2-1