### PR TITLE
Set up trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish to PyPI
+on:
+  release:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+    types: [released]
+jobs:
+  test:
+    uses: ./.github/workflows/python-tox.yml
+
+  build:
+    needs: ['test']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install Python dependencies
+        run: pip install build
+
+      - name: Build package distributions
+        run: python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./dist
+
+  # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+  pypi-publish:
+    needs: ['build']
+    environment: 'publish'
+
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # Mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: artifact/
+          print-hash: true

--- a/README.md
+++ b/README.md
@@ -69,3 +69,16 @@ The template tag can then be used like so:
 ```jinja2
 {{ tota11y() }}
 ```
+
+## Release process
+
+This section is for maintainers of this package.
+
+1. Ensure `CHANGELOG.md` is up to date.
+   - Don't forget to update the release date
+   - Consider the perspective of the person reading the changelog. What do they need to know? Keep it short and to the point, most important bits first.
+2. Check the version number in `setup.py` and update it if necessary. Follow [semantic versioning](https://semver.org/).
+3. Commit and push the changes
+4. From the GitHub interface, create a new release, using the version number as the tag name (GitHub will create the tag for you)
+   - GitHub Actions will automatically build and publish the new version to PyPI when a GitHub release is created
+5. Back to development: Update the version number in `setup.py` to the next version, and add a new section to `CHANGELOG.md` for the next release (with a date of "unreleased")


### PR DESCRIPTION
This PR automates the release process to PyPI using [trusted publishing](https://docs.pypi.org/trusted-publishers/).

Some additional setup is required in PyPI's interface. See https://docs.pypi.org/trusted-publishers/adding-a-publisher/

@zerolab or @thibaudcolas, since you are both listed as maintainers, can one of you add a trusted publisher with the following details:

Owner: wagtail-nest
Repository name: wagtail-accessibility
Workflow name: publish.yml
Environment name: publish

Thanks!