### PR TITLE
Wagtail 6.4

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -2,6 +2,10 @@ name: Python Tests
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 3.14.6
 envlist =
-    py{39,310,311}-dj42-wagtail{52,60,61,62,63,64}
-    py{310,311,312}-dj{50,51,52}-wagtail{52,60,61,62,63,64}
-    py313-dj51-wagtail64
+    py{39,310,311,312}-dj42-wagtail{52,60,61,62,63,64}
+    py{310,311,312}-dj{50,51}-wagtail{52,60,61,62,63,64}
+    py313-dj51-wagtail{63,64}
     coverage-report
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,32 @@
 [tox]
 minversion = 3.14.6
 envlist =
-    py{38,39,310}-dj32-wagtail52
-    py{38,39,310,311}-dj42-wagtail{52,60,61}
-    py{310,311,312}-dj50-wagtail{52,60,61}
+    py{39,310,311}-dj42-wagtail{52,60,61,62,63,64}
+    py{310,311,312}-dj{50,51,52}-wagtail{52,60,61,62,63,64}
+    py313-dj51-wagtail64
     coverage-report
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 extras = test
 deps =
-    dj32: django>=3.2,<3.3
     dj42: django>=4.2,<4.3
     dj50: django>=5.0,<5.1
+    dj51: django>=5.0,<5.2
     wagtail52: wagtail>=5.2,<5.3
     wagtail60: wagtail>=6.0,<6.1
     wagtail61: wagtail>=6.1,<6.2
+    wagtail62: wagtail>=6.2,<6.3
+    wagtail63: wagtail>=6.3,<6.4
+    wagtail64: wagtail>=6.4,<6.5
 
 [testenv:coverage-report]
 basepython = python3.12


### PR DESCRIPTION
This pull request includes updates to the Python test configurations and dependencies to support new versions of Python, Django, and Wagtail. 

Updates to GitHub workflow:

*Added concurrency control to prevent multiple runs of the same workflow and updated the Python versions matrix to include Python 3.13.

Updates to `tox.ini`:

* Expanded the `envlist` to include new combinations of Django and Wagtail versions, including Django 5.1 and Wagtail 6.2 to 6.4, and added support for Python 3.13.