### PR TITLE
Update to support Wagtail 7.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Install Python dependencies
         run: pip install build

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased] - YYYY-MM-DD
 
+- Update minimum Wagtail version to 6.3 [@damwaingames](https://github.com/damwaingames)
+- Change tox matrix to only supported versions of Django (4.2, 5.1, 5.2) and Wagtail (6.3, 7.0, 7.1) [@damwaingames](https://github.com/damwaingames)
+- Remove python 3.8 support [@damwaingames](https://github.com/damwaingames)
+- Added python 3.13 support [@damwaingames](https://github.com/damwaingames)
+- Updated requirements and setup to more recent packages [@damwaingames](https://github.com/damwaingames)
+
 - Adjust test matrix to use Wagtail 6 [@katdom13](https://github.com/katdom13)
 - Drop Wagtail < 5.2 from the test matrix [@katdom13](https://github.com/katdom13)
 - Add Python 3.12 to test matrix [@katdom13](https://github.com/katdom13)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ wagtail>=6.3
 pytest==8.4.1
 pytest-cov==6.2.1
 pytest-django==4.11.1
-coverage==7.10.4
+coverage==7.6.1
 tox-gh-actions>=3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-wagtail>=5.2
-pytest==6.2.5
-pytest-cov==3.0.0
-pytest-django==4.5.0
-pytest-pythonpath==0.7.3
-coverage==6.0
-tox-gh-actions>=3.1
+wagtail>=6.3
+pytest==8.4.1
+pytest-cov==6.2.1
+pytest-django==4.11.1
+coverage==7.10.4
+tox-gh-actions>=3.3.0

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,14 @@ with open("README.md", encoding="utf-8") as readme_file:
 
 
 install_requires = [
-    'wagtail>=5.2',
+    'wagtail>=6.3',
 ]
 
 tests_require = [
-    "pytest==6.2.5",
-    "pytest-cov==3.0.0",
-    "pytest-django==4.5.0",
-    "pytest-pythonpath==0.7.3",
-    "coverage==6.0",
+    "pytest==8.4.1",
+    "pytest-cov==6.2.1",
+    "pytest-django==4.11.1",
+    "coverage==7.10.4",
 ]
 
 setup(
@@ -51,18 +50,18 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Site Management',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",
-        "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
+        "Framework :: Django :: 5.2",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",
+        "Framework :: Wagtail :: 7",
         'License :: OSI Approved :: BSD License',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ tests_require = [
     "pytest==8.4.1",
     "pytest-cov==6.2.1",
     "pytest-django==4.11.1",
-    "coverage==7.10.4",
+    "coverage==7.6.1",
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,32 +1,32 @@
 [tox]
 minversion = 3.14.6
 envlist =
-    py{38,39,310}-dj32-wagtail52
-    py{38,39,310,311}-dj42-wagtail{52,60,61}
-    py{310,311,312}-dj50-wagtail{52,60,61}
+    py{39,310,311}-dj42-wagtail{63,70,71}
+    py{310,311,312}-dj51-wagtail{63,70,71}
+    py{312,313}-dj52-wagtail{70,71}
     coverage-report
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 extras = test
 deps =
-    dj32: django>=3.2,<3.3
     dj42: django>=4.2,<4.3
-    dj50: django>=5.0,<5.1
-    wagtail52: wagtail>=5.2,<5.3
-    wagtail60: wagtail>=6.0,<6.1
-    wagtail61: wagtail>=6.1,<6.2
+    dj51: django>=5.1,<5.2
+    dj52: django>=5.2,<5.3
+    wagtail63: wagtail>=6.3,<6.4
+    wagtail70: wagtail>=7.0,<7.1
+    wagtail71: wagtail>=7.1,<7.2
 
 [testenv:coverage-report]
-basepython = python3.12
+basepython = python3.13
 deps = coverage
 pip_pre = true
 skip_install = true


### PR DESCRIPTION
The changes primarily focus on updating the supported versions of Python, Django, and Wagtail, and removing support for older versions.

Supersedes PR https://github.com/wagtail-nest/wagtail-accessibility/pull/18 and https://github.com/wagtail-nest/wagtail-accessibility/pull/19

### Updates to supported versions
- Python: Removed support for 3.8, added support for 3.13
- Django: Removed support for 3.2 and 5.0 (EOL), added support for 5.2
- Wagtail: Removed support for versions <6.3 (EOL), added support for 7.0 and 7.1
- Updated testing packages to more modern packages
- Updated PyPi classifiers

### Documentation updates
- Updated CHANGELOG


